### PR TITLE
Exponential fog implementation

### DIFF
--- a/ProceduralCity/GameObjects/Textbox.cs
+++ b/ProceduralCity/GameObjects/Textbox.cs
@@ -77,7 +77,7 @@ namespace ProceduralCity.GameObjects
             CursorAdvance = 0;
             _fontmap = new Texture($"{fontName}/font.png", "Fonts");
             _fontConfig = new FontConfig(fontName);
-            _shader = new Shader("vs.vert", "font.frag");
+            _shader = new Shader("vs.vert", new[] { "font.frag", "colorTools.frag" });
             _shader.SetUniformValue("tex", new IntUniform
             {
                 Value = 0

--- a/ProceduralCity/Generators/BillboardTextureGenerator.cs
+++ b/ProceduralCity/Generators/BillboardTextureGenerator.cs
@@ -16,15 +16,6 @@ namespace ProceduralCity.Generators
         private readonly ILogger _logger;
         private readonly IAppConfig _config;
         private readonly Matrix4 _projectionMatrix;
-        private readonly List<Vector3> _billboardColors = new()
-        {
-            new Vector3(0.839f, 0.325f, 1f),
-            new Vector3(0.506f, 0.969f, 0.996f),
-            new Vector3(0.472f, 0.964f, 0.984f),
-            new Vector3(0.144f, 1f, 0.961f),
-            new Vector3(0.531f, 0.373f, 1f),
-            new Vector3(0.183f, 0.528f, 0.973f),
-        };
 
         private static readonly string[] _prefixes = new[]
         {
@@ -102,13 +93,13 @@ namespace ProceduralCity.Generators
             foreach (var tex in textures)
             {
                 var word = GenerateBillboardText();
-                var color = _billboardColors[_random.Next(_billboardColors.Count)];
 
                 using var text = new Textbox("Consolas")
                     .WithText(word, new Vector2(), 1.5f)
-                    .WithHue(color.X)
-                    .WithSaturation(color.Y)
-                    .WithValue(color.Z);
+                    .WithHue(1.0f)
+                    .WithSaturation(0)
+                    .WithValue(1.0f);
+
                 using var renderer = new Renderer.Renderer();
                 using var backbufferRenderer = new BackBufferRenderer(_logger, tex, tex.Width, tex.Height, false);
                 renderer.BeforeRender = () => { GL.Enable(EnableCap.Blend); };

--- a/ProceduralCity/Generators/ColorGenerator.cs
+++ b/ProceduralCity/Generators/ColorGenerator.cs
@@ -1,0 +1,65 @@
+﻿using OpenTK.Mathematics;
+
+using System;
+
+namespace ProceduralCity.Generators
+{
+    public class ColorGenerator
+    {
+        private readonly Random _random = new();
+
+        // RGB colors
+        private readonly Color4[] _cloudColors = new[]
+        {
+            new Color4(0, 1.0f, 0, 1), //green
+            new Color4(0, 0, 1.0f, 1), //blue
+            new Color4(1, 0, 0, 1), //red
+            new Color4(0.59f, 0.29f, 0, 1), //brown
+            new Color4(1.0f, 0.50f, 0, 1), //orange
+            new Color4(0.6f, 0, 0.6f, 1), //purple
+            new Color4(1.0f, 1.0f, 0.1f, 1), //yellow
+            new Color4(1.0f, 0.2f, 0.33f, 1), //"radical red"
+        };
+
+        public Color4 Primary { get; private set; } = Color4.Black;
+        public Color4 Secondary { get; private set; } = Color4.Black;
+
+        private static Color4 MixedColor(Color4 c1, Color4 c2)
+        {
+            var color1AsVector = new Vector3(c1.R, c1.G, c1.B);
+            var color2AsVector = new Vector3(c2.R, c2.G, c2.B);
+
+            /*
+             * This is a totally arbitrary value for the mixed colors, which happens to be correct 95% of the times.
+             * In the remaining times the vector values are so low, that the mixed color is black, resulting in
+             * essentially a cloudless night. I am still unsure if this should be considered a bug or a feature.
+             */
+            var mixed = Vector3.Clamp((color1AsVector + color2AsVector) * 0.3f, new Vector3(0f), new Vector3(1f));
+            return new Color4(mixed.X, mixed.Y, mixed.Z, 1f);
+        }
+
+        public delegate void ColorChangedEvent();
+
+        public event ColorChangedEvent OnColorChanged;
+
+        public Color4 Mixed
+        {
+            get => MixedColor(Primary, Secondary);
+        }
+        
+        public ColorGenerator()
+        {
+            GenerateColors();
+        }
+
+        public void GenerateColors()
+        {
+            var primaryIndex = _random.Next(0, _cloudColors.Length);
+            var secondaryIndex = _random.Next(0, _cloudColors.Length);
+
+            Primary = _cloudColors[primaryIndex];
+            Secondary =  _cloudColors[secondaryIndex];
+            OnColorChanged?.Invoke();
+        }
+    }
+}

--- a/ProceduralCity/ProceduralCity.csproj
+++ b/ProceduralCity/ProceduralCity.csproj
@@ -14,13 +14,25 @@
     <None Update="Fonts\Consolas\font.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Shaders\billboard.frag">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Shaders\colorTools.frag">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Shaders\FlatColored.frag">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Shaders\fog.frag">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Shaders\font.frag">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Shaders\fs.frag">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Shaders\fullscreen.frag">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Shaders\instanced.vert">

--- a/ProceduralCity/Program.cs
+++ b/ProceduralCity/Program.cs
@@ -42,6 +42,7 @@ namespace ProceduralCity
             builder.RegisterType<ProceduralSkybox>().As<ISkybox>().SingleInstance();
             builder.RegisterType<BillboardTextureGenerator>().As<IBillboardTextureGenerator>().SingleInstance();
             builder.RegisterType<BillboardBuilder>().As<IBillboardBuilder>().SingleInstance();
+            builder.RegisterType<ColorGenerator>().SingleInstance();
 
             return builder.Build();
         }

--- a/ProceduralCity/Renderer/IRenderer.cs
+++ b/ProceduralCity/Renderer/IRenderer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using OpenTK;
 using OpenTK.Mathematics;
 
 namespace ProceduralCity.Renderer

--- a/ProceduralCity/Renderer/PostProcess/PostprocessPipeline.cs
+++ b/ProceduralCity/Renderer/PostProcess/PostprocessPipeline.cs
@@ -23,15 +23,15 @@ namespace ProceduralCity.Renderer.PostProcess
         public PostprocessPipeline(ILogger logger, IAppConfig config, Texture inputTexture, Texture outputTexture)
         {
             _logger = logger;
-            _inputTexture = inputTexture;
+            _inputTexture = inputTexture; // Rendered 3D world
             _outputTexture = outputTexture;
 
             _postprocess = new List<PostProcess>()
             {
+                // All three needed for the bloom effect
                 new PostProcess(logger, new[] { _inputTexture }, _outputTexture, _lumaEffect),
                 new PostProcess(logger, new[] { _outputTexture }, _outputTexture, _horizontalBlurEffect),
                 new PostProcess(logger, new[] { _outputTexture }, _outputTexture, _verticalBlurEffect),
-
                 new PostProcess(logger, new[] { _inputTexture, _outputTexture }, _outputTexture, _blendEffect),
             };
 

--- a/ProceduralCity/Renderer/ProceduralSkybox.cs
+++ b/ProceduralCity/Renderer/ProceduralSkybox.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenTK.Mathematics;
 
+using ProceduralCity.Generators;
 using ProceduralCity.Renderer.Uniform;
 using Serilog;
 
@@ -14,17 +15,7 @@ namespace ProceduralCity.Renderer
         private readonly Random _random = new();
         private readonly List<Mesh> _meshes = new();
         private readonly Shader _shader;
-        private readonly Vector3[] _cloudColors = new[]
-        {
-            new Vector3(0, 1.0f, 0), //green
-            new Vector3(0, 0, 1.0f), //blue
-            new Vector3(1, 0, 0), //red
-            new Vector3(0.59f, 0.29f, 0), //brown
-            new Vector3(1.0f, 0.50f, 0), //orange
-            new Vector3(0.6f, 0, 0.6f), //purple
-            new Vector3(1.0f, 1.0f, 0.1f), //yellow
-            new Vector3(1.0f, 0.2f, 0.33f), //"radical red"
-        };
+        private readonly ColorGenerator _colorGenerator;
 
         public IEnumerable<Mesh> Meshes
         {
@@ -34,10 +25,12 @@ namespace ProceduralCity.Renderer
             }
         }
 
-        public ProceduralSkybox(ILogger logger)
+        public ProceduralSkybox(ILogger logger, ColorGenerator colorGenerator)
         {
             _logger = logger;
             _shader = new Shader("skybox/skybox.vert", "skybox/proceduralSkybox.frag");
+            _colorGenerator = colorGenerator;
+
             GenerateSky();
 
             var vertices = CreateVertices();
@@ -53,11 +46,15 @@ namespace ProceduralCity.Renderer
 
         private void GenerateSky()
         {
-            var (color1, color2) = GenerateCloudColors();
-            var skyColor = Vector3.Clamp(MixCloudColors(color1, color2), new Vector3(0), new Vector3(1));
-            SetSkyColor(skyColor, skyColor * 0.15f);
+            var (color1, color2) = (_colorGenerator.Primary, _colorGenerator.Secondary);
+            SetCloudColors(color1, color2);
+
+            // This is the gradient color of the sky, without the clouds
+            var skyColor = new Vector3(_colorGenerator.Mixed.R, _colorGenerator.Mixed.G, _colorGenerator.Mixed.B);
+            SetSkyTransientColor(skyColor, skyColor * 0.15f);
+
             SetCloudCutoffValue();
-            SetSeeds();
+            SetSeeds(); // Sets the seeds for the value noise algorithm
         }
 
         private void SetSeeds()
@@ -89,12 +86,7 @@ namespace ProceduralCity.Renderer
             });
         }
 
-        private static Vector3 MixCloudColors(Vector3 color1, Vector3 color2)
-        {
-            return (color1 + color2) * 0.3f;
-        }
-
-        private void SetSkyColor(Vector3 bottomColor, Vector3 topColor)
+        private void SetSkyTransientColor(Vector3 bottomColor, Vector3 topColor)
         {
             _shader.SetUniformValue("u_sky_bottom_color", new Vector3Uniform
             {
@@ -119,22 +111,19 @@ namespace ProceduralCity.Renderer
             _logger.Information("Cloud cutoff value set to: {cutoff}", cutoff);
         }
 
-        private (Vector3 color1, Vector3 color2) GenerateCloudColors()
+        private void SetCloudColors(Color4 color1, Color4 color2)
         {
-            var cloudColor1 = _cloudColors[_random.Next(0, _cloudColors.Length)];
             _shader.SetUniformValue("u_cloud_color_1", new Vector3Uniform
             {
-                Value = cloudColor1
+                Value = new Vector3(color1.R, color1.G, color1.B)
             });
 
-            var cloudColor2 = _cloudColors[_random.Next(0, _cloudColors.Length)];
             _shader.SetUniformValue("u_cloud_color_2", new Vector3Uniform
             {
-                Value = cloudColor2
+                Value = new Vector3(color2.R, color2.G, color2.B)
             });
 
-            _logger.Information("Generated cloud colors: {cloudColor1}, {cloudColor2}", cloudColor1, cloudColor2);
-            return (cloudColor1, cloudColor2);
+            _logger.Information("Cloud colors set to: {cloudColor1}, {cloudColor2}", color1, color2);
         }
 
         private static IEnumerable<Vector3> CreateVertices()

--- a/ProceduralCity/Renderer/Uniform/FloatUniform.cs
+++ b/ProceduralCity/Renderer/Uniform/FloatUniform.cs
@@ -1,11 +1,11 @@
 ﻿namespace ProceduralCity.Renderer.Uniform
 {
-    struct FloatUniform : IUniformValue
+    readonly struct FloatUniform : IUniformValue
     {
         public float Value
         {
             get;
-            set;
+            init;
         }
 
         public readonly void Visit(int location, UniformHandler uniformHandler)

--- a/ProceduralCity/Renderer/Uniform/IntUniform.cs
+++ b/ProceduralCity/Renderer/Uniform/IntUniform.cs
@@ -1,8 +1,8 @@
 ﻿namespace ProceduralCity.Renderer.Uniform
 {
-    struct IntUniform : IUniformValue
+    readonly struct IntUniform : IUniformValue
     {
-        public int Value { get; set; }
+        public int Value { get; init; }
 
         public readonly void Visit(int location, UniformHandler uniformHandler)
         {

--- a/ProceduralCity/Renderer/Uniform/Matrix4Uniform.cs
+++ b/ProceduralCity/Renderer/Uniform/Matrix4Uniform.cs
@@ -2,12 +2,12 @@
 
 namespace ProceduralCity.Renderer.Uniform
 {
-    struct Matrix4Uniform : IUniformValue
+    readonly struct Matrix4Uniform : IUniformValue
     {
         public Matrix4 Value
         {
             get;
-            set;
+            init;
         }
 
         public readonly void Visit(int location, UniformHandler uniformHandler)

--- a/ProceduralCity/Renderer/Uniform/Vector2Uniform.cs
+++ b/ProceduralCity/Renderer/Uniform/Vector2Uniform.cs
@@ -2,12 +2,12 @@
 
 namespace ProceduralCity.Renderer.Uniform
 {
-    struct Vector2Uniform : IUniformValue
+    readonly struct Vector2Uniform : IUniformValue
     {
         public Vector2 Value
         {
             get;
-            set;
+            init;
         }
 
         public readonly void Visit(int location, UniformHandler uniformHandler)

--- a/ProceduralCity/Renderer/Uniform/Vector3Uniform.cs
+++ b/ProceduralCity/Renderer/Uniform/Vector3Uniform.cs
@@ -2,12 +2,12 @@
 
 namespace ProceduralCity.Renderer.Uniform
 {
-    struct Vector3Uniform : IUniformValue
+    readonly struct Vector3Uniform : IUniformValue
     {
-        public Vector3 Value
+        public readonly Vector3 Value
         {
             get;
-            set;
+            init;
         }
 
         public readonly void Visit(int location, UniformHandler uniformHandler)

--- a/ProceduralCity/Shaders/FlatColored.frag
+++ b/ProceduralCity/Shaders/FlatColored.frag
@@ -1,11 +1,21 @@
 ﻿#version 330
 
+// Dependencies: exponentialFog definition
+
+// A shader for untextured meshes. Needs a color value provided as a uniform.
+// Flat colored meshes are affected by the value too. Should be linked with a shader containing the definition of the exponential fog function.
+
 in vec2 texCoords;
 out vec4 fragColor;
 
 uniform vec3 u_color;
+uniform vec3 fogColor;
+
+// Forward declaration of the exponential fog function. This shader file should be linked with a shader containing the definintion
+float exponentialFog();
 
 void main()
 {
-	fragColor = vec4(u_color, 1);
+	float fogFactor = exponentialFog();
+	fragColor = mix(vec4(fogColor, 1.0), vec4(u_color, 1), fogFactor);
 }

--- a/ProceduralCity/Shaders/PostProcess/luminance.frag
+++ b/ProceduralCity/Shaders/PostProcess/luminance.frag
@@ -14,10 +14,10 @@ void main()
 
 	if(luminance < u_LuminanceTreshold)
 	{
-		fragmentColor = vec4(0);
+		fragmentColor = vec4(0); // Postprocess pipeline is additive. Returning 0 essentially leaves the pixel unchanged.
 	}
 	else
 	{
-		fragmentColor = texture(tex, fTexCoord) * mix(0, 1, 1.0f/u_LuminanceTreshold);
+		fragmentColor = texture(tex, fTexCoord) * clamp(0, 1, smoothstep(0, .4f, 1.0f/u_LuminanceTreshold));
 	}
 }

--- a/ProceduralCity/Shaders/billboard.frag
+++ b/ProceduralCity/Shaders/billboard.frag
@@ -1,0 +1,14 @@
+﻿#version 330
+
+in vec2 fTexCoord;
+out vec4 fragmentColor;
+
+uniform sampler2D tex;
+uniform vec3 billboardColor = vec3(1, 0, 1); // HSV
+
+vec3 hsvToRgb(float h, float s, float v);
+
+void main()
+{
+	fragmentColor = texture(tex, fTexCoord) * vec4(hsvToRgb(billboardColor.x, billboardColor.y, billboardColor.z), 1);
+}

--- a/ProceduralCity/Shaders/colorTools.frag
+++ b/ProceduralCity/Shaders/colorTools.frag
@@ -1,0 +1,19 @@
+﻿#version 330
+
+// Not a standalone shader.
+
+//HSV to RGB: http://www.chilliant.com/rgb2hsv.html
+#define saturate(x) clamp(x, 0., 1.)
+vec3 hueToRgb(float h)
+{
+	float r = abs(h * 6 - 3) - 1;
+	float g = 2 - abs(h * 6 - 2);
+	float b = 2 - abs(h * 6 - 4);
+	return saturate(vec3(r,g,b));
+}
+
+vec3 hsvToRgb(float h, float s, float v)
+{
+	vec3 rgb = hueToRgb(h);
+	return ((rgb - 1) * s + 1) * v;
+}

--- a/ProceduralCity/Shaders/fog.frag
+++ b/ProceduralCity/Shaders/fog.frag
@@ -1,0 +1,11 @@
+﻿#version 330
+
+// Contains the definition for the exponential fog. Not a standalone shader.
+
+uniform float fogDensity = 4.0f;
+float exponentialFog()
+{
+	float z = (gl_FragCoord.z / gl_FragCoord.w) / 5000.0;
+	float factor = exp(-pow(z * fogDensity, 2.0));
+	return clamp(0, 1, factor);
+}

--- a/ProceduralCity/Shaders/font.frag
+++ b/ProceduralCity/Shaders/font.frag
@@ -9,21 +9,7 @@ uniform float saturation = 0;
 uniform float value = 1;
 const float gCutoff = 0.1;
 
-//HSV to RGB: http://www.chilliant.com/rgb2hsv.html
-#define saturate(x) clamp(x, 0., 1.)
-vec3 hueToRgb(float h)
-{
-	float r = abs(h * 6 - 3) - 1;
-	float g = 2 - abs(h * 6 - 2);
-	float b = 2 - abs(h * 6 - 4);
-	return saturate(vec3(r,g,b));
-}
-
-vec3 hsvToRgb(float h, float s, float v)
-{
-	vec3 rgb = hueToRgb(h);
-	return ((rgb - 1) * s + 1) * v;
-}
+vec3 hsvToRgb(float h, float s, float v);
 
 float clip(float alpha, float cutoff)
 {

--- a/ProceduralCity/Shaders/fs.frag
+++ b/ProceduralCity/Shaders/fs.frag
@@ -3,9 +3,27 @@ in vec2 fTexCoord;
 out vec4 fragmentColor;
 
 uniform sampler2D tex;
-uniform float fadeFactor = 1.0f;
+uniform vec3 fogColor;
+
+// Linear fog
+//float near = 0.01f;
+//float far = 50.0f;
+//
+//float linearizeDepth(float depth)
+//{
+//	return (2.0f * near * far) / (far + near  - (depth * 2.0f - 1.0f) * (far - near));
+//}
+
+float exponentialFog();
 
 void main()
 {
-	fragmentColor = texture(tex, fTexCoord) * fadeFactor;
+// Old fog calculation
+//	float originalZ = linearizeDepth(gl_FragCoord.z) / far;
+//	float fogFactor = 1.0f - originalZ;
+//	fragmentColor = mix(vec4(fogColor, 1.0), texture(tex, fTexCoord), vec4(vec3(fogFactor), 1.0));
+
+	// New fog calculation
+	float factor = exponentialFog();
+	fragmentColor = mix(vec4(fogColor, 1.0), texture(tex, fTexCoord), factor);
 }

--- a/ProceduralCity/Shaders/fullscreen.frag
+++ b/ProceduralCity/Shaders/fullscreen.frag
@@ -1,0 +1,11 @@
+﻿#version 330
+in vec2 fTexCoord;
+out vec4 fragmentColor;
+
+uniform sampler2D tex;
+uniform float fadeFactor = 1.0f;
+
+void main()
+{
+	fragmentColor = texture(tex, fTexCoord) * fadeFactor;
+}


### PR DESCRIPTION
- Exponential fog in fragment shader
- Global color service for the commonly used color values
- Removed hard coded billboard color values
- Billboards are now colored in fragment shader based on the global color value
- Shaders can now link multiple shaders together for the same type (eg. multiple fragment shaders. This can reduce some code duplication in the shaders)
- Moved hueCoverter and xy shared shader codes into separate files to reduce duplication
- Uniforms are now readonly